### PR TITLE
[Fix] Improving spawner drop logic

### DIFF
--- a/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerBreakListener.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerBreakListener.java
@@ -26,6 +26,7 @@ import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.util.Vector;
 
 import java.util.Map;
 
@@ -146,7 +147,7 @@ public class SpawnerBreakListener implements Listener {
                 giveSpawnersToPlayer(player, 1, spawnerItem);
                 player.playSound(player.getLocation(), Sound.ENTITY_ITEM_PICKUP, 0.5f, 1.2f);
             } else {
-                world.dropItemNaturally(location, spawnerItem);
+                world.dropItemNaturally(location.toCenterLocation(), spawnerItem);
             }
 
             reduceDurability(tool, player, plugin.getConfig().getInt("spawner_break.durability_loss", 1));
@@ -227,7 +228,7 @@ public class SpawnerBreakListener implements Listener {
             player.playSound(player.getLocation(), Sound.ENTITY_ITEM_PICKUP, 0.5f, 1.2f);
         } else {
             template.setAmount(dropAmount);
-            world.dropItemNaturally(location, template.clone());
+            world.dropItemNaturally(location.toCenterLocation(), template.clone()).getVelocity();
         }
 
         return new SpawnerBreakResult(true, dropAmount, durabilityLoss);
@@ -297,7 +298,7 @@ public class SpawnerBreakListener implements Listener {
 
         if (!failedItems.isEmpty()) {
             for (ItemStack failedItem : failedItems.values()) {
-                player.getWorld().dropItemNaturally(player.getLocation(), failedItem);
+                player.getWorld().dropItemNaturally(player.getLocation().toCenterLocation(), failedItem);
             }
             messageService.sendMessage(player, "inventory_full_items_dropped");
         }

--- a/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerBreakListener.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerBreakListener.java
@@ -26,7 +26,6 @@ import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.util.Vector;
 
 import java.util.Map;
 

--- a/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerBreakListener.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerBreakListener.java
@@ -227,7 +227,7 @@ public class SpawnerBreakListener implements Listener {
             player.playSound(player.getLocation(), Sound.ENTITY_ITEM_PICKUP, 0.5f, 1.2f);
         } else {
             template.setAmount(dropAmount);
-            world.dropItemNaturally(location.toCenterLocation(), template.clone()).getVelocity();
+            world.dropItemNaturally(location.toCenterLocation(), template.clone());
         }
 
         return new SpawnerBreakResult(true, dropAmount, durabilityLoss);


### PR DESCRIPTION
It is a known issue that spawner would likely drop in solid blocks, making them either move up to the surface or into the next cave / empty spot.

I investigated both item velocity and drop locations to address this issue and found out that the easiest and least changing fix was transforming the location to the center. 
This ensures that the server picks a direction where the item can drop safely without getting in solid blocks. I tried this myself ensuring 100% correct drop directions.

This is a very light but impactful change, i hope this will get merged, since many people reported this before also bothering the majority of my playerbase.

Locations where you notice this change the most are setups like this
![2025-06-16_21 53 37](https://github.com/user-attachments/assets/032942bc-6a60-4841-a92f-d6ddf80cee81)
Which is pretty common on server without world protection for players.

Thanks for taking a look!