### PR TITLE
fix: Don't stack ShopGUI+ listeners & unregister upon clean-up

### DIFF
--- a/core/src/main/java/github/nighter/smartspawner/hooks/economy/shops/providers/shopguiplus/SpawnerHook.java
+++ b/core/src/main/java/github/nighter/smartspawner/hooks/economy/shops/providers/shopguiplus/SpawnerHook.java
@@ -54,4 +54,10 @@ public class SpawnerHook implements Listener{
             }
         }
     }
+
+    public void unregister() {
+        ShopGUIPlusPostEnableEvent.getHandlerList().unregister(this);
+        ShopsPostLoadEvent.getHandlerList().unregister(this);
+        plugin.debug("Unregistered SpawnerHook event listener");
+    }
 }


### PR DESCRIPTION
Fixes #108: integration stacking where each listener registers a new listener.